### PR TITLE
Fix build failure

### DIFF
--- a/com.sap.dirigible/com.sap.dirigible.parent/com.sap.dirigible.ide/com.sap.dirigible.ide.workspace.wizard.project/src/com/sap/dirigible/ide/workspace/wizard/project/sample/SampleProjectWizardGitTemplatePage.java
+++ b/com.sap.dirigible/com.sap.dirigible.parent/com.sap.dirigible.ide/com.sap.dirigible.ide.workspace.wizard.project/src/com/sap/dirigible/ide/workspace/wizard/project/sample/SampleProjectWizardGitTemplatePage.java
@@ -300,7 +300,7 @@ public class SampleProjectWizardGitTemplatePage extends WizardPage {
 
 	private static void doClone(File gitDirectory) {
 		try {
-			JGitConnector.cloneRepository(CommonParameters.GIT_REPOSITORY_URL, gitDirectory);
+			JGitConnector.cloneRepository(gitDirectory, CommonParameters.GIT_REPOSITORY_URL);
 		} catch (InvalidRemoteException e) {
 			e.printStackTrace();
 		} catch (TransportException e) {


### PR DESCRIPTION
The build failed because the formal and actual parameters  for JGitConnector.cloneRepository() didn't match. See build 63 of the Travis CI: https://travis-ci.org/SAP/cloud-dirigible/builds/30173519
